### PR TITLE
Repalce "nice" to "defer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ zplug 'zsh-users/zaw'
 # zplug 'rupa/z', \
 zplug 'knu/z', \
     use:'z.sh', \
-    nice:10
+    defer:2
 
 zplug 'NigoroJr/zaw-z', \
-    nice:11, \
+    defer:3, \
     on:'zsh-users/zaw'
 
 zplug check || zplug install


### PR DESCRIPTION
First, thanks for great plugin.

I got the following warning.
```
[zplug] WARNING: 'nice' tag is deprecated. Please use 'defer' tag instead (knu/z).
[zplug] WARNING: 'nice' tag is deprecated. Please use 'defer' tag instead (NigoroJr/zaw-z).
```
And in my environment, if I use 'nice' tag, zaw-z throws the following error.
```
No such widget `zaw-z'
```

So, I replace 'nice' tog to 'defer'. Now it works fine.
